### PR TITLE
Fix Log Collection and Execution Order

### DIFF
--- a/MakeMeAnAdmin.sh
+++ b/MakeMeAnAdmin.sh
@@ -35,7 +35,7 @@ sudo defaults write /Library/LaunchDaemons/removeAdmin.plist Label -string "remo
 #Add program argument to have it run the update script
 sudo defaults write /Library/LaunchDaemons/removeAdmin.plist ProgramArguments -array -string /bin/sh -string "/Library/Application Support/JAMF/removeAdminRights.sh"
 
-#Set the run inverval to run every 7 days
+#Set the run inverval 30 minutes
 sudo defaults write /Library/LaunchDaemons/removeAdmin.plist StartInterval -integer 1800
 
 #Set run at load
@@ -81,6 +81,7 @@ if [[ -f /private/var/userToRemove/user ]]; then
 	launchctl unload /Library/LaunchDaemons/removeAdmin.plist
 	rm /Library/LaunchDaemons/removeAdmin.plist
 	log collect --last 30m --output /private/var/userToRemove/$userToRemove.logarchive
+	launchctl remove removeAdmin
 fi
 EOF
 

--- a/MakeMeAnAdmin.sh
+++ b/MakeMeAnAdmin.sh
@@ -35,7 +35,7 @@ sudo defaults write /Library/LaunchDaemons/removeAdmin.plist Label -string "remo
 #Add program argument to have it run the update script
 sudo defaults write /Library/LaunchDaemons/removeAdmin.plist ProgramArguments -array -string /bin/sh -string "/Library/Application Support/JAMF/removeAdminRights.sh"
 
-#Set the run inverval 30 minutes
+#Set the run interval to 30 minutes
 sudo defaults write /Library/LaunchDaemons/removeAdmin.plist StartInterval -integer 1800
 
 #Set run at load

--- a/MakeMeAnAdmin.sh
+++ b/MakeMeAnAdmin.sh
@@ -78,7 +78,6 @@ if [[ -f /private/var/userToRemove/user ]]; then
 	echo "Removing $userToRemove's admin privileges"
 	/usr/sbin/dseditgroup -o edit -d $userToRemove -t user admin
 	rm -f /private/var/userToRemove/user
-	launchctl unload /Library/LaunchDaemons/removeAdmin.plist
 	rm /Library/LaunchDaemons/removeAdmin.plist
 	log collect --last 30m --output /private/var/userToRemove/$userToRemove.logarchive
 	launchctl remove removeAdmin


### PR DESCRIPTION
Change order of secondary script to only stop the daemon after the script has finished.
Previously the daemon was unloaded prior to removing the daemon's plist and collecting the logs which stopped script execution prematurely.

#1 