### PR TITLE
Update Logic to Capture Logged in User

### DIFF
--- a/MakeMeAnAdmin.sh
+++ b/MakeMeAnAdmin.sh
@@ -18,7 +18,7 @@
 # find the logged in user and let them know #
 #############################################
 
-currentUser=$(who | awk '/console/{print $1}')
+currentUser=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }')
 echo $currentUser
 
 osascript -e 'display dialog "You now have administrative rights for 30 minutes. DO NOT ABUSE THIS PRIVILEGE..." buttons {"Make me an admin, please"} default button 1'


### PR DESCRIPTION
update logic to capture currently logged in user so that it no longer captures multiple users and fails.

Just tested this and updating this single line, allows it to work properly on the latest macOS version. It still shows errors in the output (policy logs from Jamf Pro) but it works as expected again.